### PR TITLE
Formally declare the dependency on Emacs 24.3

### DIFF
--- a/html-check-frag.el
+++ b/html-check-frag.el
@@ -3,6 +3,7 @@
 ;; Copyright (C) 2013  Tobias.Zawada
 
 ;; Author: Tobias.Zawada <i@tn-home.de>
+;; Package-Requires: ((emacs "24.3"))
 
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
This allows package.el to determine whether the file is installable in a particular Emacs version.

See https://github.com/milkypostman/melpa/pull/3414
